### PR TITLE
Update details of fault-tolerance spec｜完善容错治理规则标准

### DIFF
--- a/specification/en/fault-tolerance.md
+++ b/specification/en/fault-tolerance.md
@@ -41,6 +41,8 @@ metadata:
   labels:
     app: my-app
 spec:
+  selector:
+    app: my-app
   targets:
     - targetResourceName: '/foo'
   strategies: 

--- a/specification/zh-Hans/fault-tolerance.md
+++ b/specification/zh-Hans/fault-tolerance.md
@@ -183,8 +183,10 @@ metadata:
   name: my-rule
   namespace: prod
   labels:
-    app: my-app # 规则配置生效的应用名
+    app: my-app 
 spec:
+  selector:
+    app: my-app # 规则配置生效的应用名
   targets:
     - targetResourceName: '/foo'
   strategies: 


### PR DESCRIPTION
完善容错治理规则标准，将标签选择功能放置到`$.spec.selector`中，保持和其他`CRD`的语义一致。