### PR TITLE
Fix the incorrect sample of HttpRouteRule.

### DIFF
--- a/specification/zh-Hans/traffic-routing.md
+++ b/specification/zh-Hans/traffic-routing.md
@@ -317,11 +317,11 @@ spec:
               exact: 12345       # 参数值
           uri:
             exact: "/index"
-      - target:
-        - workloads: tag-rule
-          name: my-app-gray
-    target:
-      - workloads: tag-rule
+        targets:
+          - workloads: tag-rule
+            name: my-app-gray
+      target:
+        workloads: tag-rule
         name: my-app-base
 ```
 ## HttpRouteRuleContext


### PR DESCRIPTION
The current sample of HttpRouteRule in the [traffic-routing](https://github.com/opensergo/opensergo-specification/blob/main/specification/zh-Hans/traffic-routing.md) spec page doesn't match the schema definition. So I made a minor fix here.